### PR TITLE
Allow 'finishes/fixes/delivers' before story IDs

### DIFF
--- a/pkg/git/client.go
+++ b/pkg/git/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	storyID         = regexp.MustCompile(`\[#(\d+)\]`)
+	storyID         = regexp.MustCompile(`\[(?:\w+ )?#(\d+)\]`)
 	submoduleCommit = regexp.MustCompile(`\+Subproject commit ([[:xdigit:]]+)\b`)
 )
 


### PR DESCRIPTION
This also adds tests for story IDs in the subject line, which seems to have already been a feature.

Signed-off-by: Jesse Weaver <jeweaver@pivotal.io>