### PR TITLE
Add support for Tracker API token authentication

### DIFF
--- a/pkg/bumper/bumper.go
+++ b/pkg/bumper/bumper.go
@@ -1,6 +1,8 @@
 package bumper
 
 import (
+	"log"
+
 	"github.com/loggregator/bumper/pkg/git"
 )
 
@@ -43,7 +45,11 @@ func (b Bumper) FindBumpSHA() string {
 	b.log.Header(b.commitRange)
 
 	commitsDesc, err := b.gc.Commits(b.commitRange)
-	if err != nil || len(commitsDesc) == 0 {
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(commitsDesc) == 0 {
 		b.log.Footer("")
 		return ""
 	}

--- a/pkg/tracker/api_http_client.go
+++ b/pkg/tracker/api_http_client.go
@@ -1,0 +1,30 @@
+package tracker
+
+import "net/http"
+
+type RequestClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type ApiHTTPClient struct {
+	client   RequestClient
+	apiToken string
+}
+
+func NewAPIHTTPClient(client RequestClient, apiToken string) *ApiHTTPClient {
+	return &ApiHTTPClient{
+		client:   client,
+		apiToken: apiToken,
+	}
+}
+
+func (c *ApiHTTPClient) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("X-TrackerToken", c.apiToken)
+
+	return c.client.Do(req)
+}

--- a/pkg/tracker/api_http_client_test.go
+++ b/pkg/tracker/api_http_client_test.go
@@ -1,0 +1,35 @@
+package tracker_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/loggregator/bumper/pkg/tracker"
+)
+
+var _ = Describe("Tracker API HTTP Client", func() {
+	It("sets the correct header", func() {
+		spyHttpClient := newSpyHTTPRequestClient()
+		apiHttpClient := tracker.NewAPIHTTPClient(spyHttpClient, "some-token")
+
+		apiHttpClient.Get("some-url")
+
+		Expect(spyHttpClient.trackerToken).To(Equal("some-token"))
+	})
+})
+
+type spyHTTPRequestClient struct {
+	trackerToken string
+}
+
+func newSpyHTTPRequestClient() *spyHTTPRequestClient {
+	return &spyHTTPRequestClient{}
+}
+
+func (t *spyHTTPRequestClient) Do(r *http.Request) (*http.Response, error) {
+	t.trackerToken = r.Header.Get("X-TrackerToken")
+
+	return nil, nil
+}

--- a/pkg/tracker/client.go
+++ b/pkg/tracker/client.go
@@ -59,7 +59,7 @@ func (c Client) story(storyID int) story {
 
 	err = json.NewDecoder(resp.Body).Decode(&s)
 	if err != nil {
-		log.Fatalf("failed to unmarshal story: %s")
+		log.Fatalf("failed to unmarshal story: %s", err)
 	}
 
 	c.cache[storyID] = s


### PR DESCRIPTION
This is required for private backlogs.

- fix a broken log.Fatalf in tracker client
- improve errors when git commands fail

Signed-off-by: Mark Gangl <mgangl@pivotal.io>